### PR TITLE
firewall: T970: Maintain a domain state to fallback if resolution fails

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -26,21 +26,20 @@ def get_ips_domains_dict(list_domains):
     """
     Get list of IPv4 addresses by list of domains
     Ex: get_ips_domains_dict(['ex1.com', 'ex2.com'])
-        ['192.0.2.1', '192.0.2.2', '192.0.2.3']
+        {'ex1.com': ['192.0.2.1'], 'ex2.com': ['192.0.2.2', '192.0.2.3']}
     """
     from socket import gethostbyname_ex
     from socket import gaierror
 
-    ip_list = []
+    ip_dict = {}
     for domain in list_domains:
         try:
             _, _, ips = gethostbyname_ex(domain)
-            for entry in ips:
-                ip_list.append(entry)
+            ip_dict[domain] = ips
         except gaierror:
             pass
 
-    return ip_list
+    return ip_dict
 
 def nft_init_set(group_name, table="filter", family="ip"):
     """

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -427,7 +427,8 @@ def apply(firewall):
                     domains.append(address)
                 # Add elements to domain-group, try to resolve domain => ip
                 # and add elements to nft set
-                elements = get_ips_domains_dict(domains)
+                ip_dict = get_ips_domains_dict(domains)
+                elements = sum(ip_dict.values(), [])
                 nft_init_set(group)
                 nft_add_set_elements(group, elements)
         else:


### PR DESCRIPTION
PR shows an example how I think resolution failure can be handled

`get_ips_domains_dict` returns a dict of domain -> IPs

* Firewall conf script applies any values initially (on first commit/on boot)
* Daemon keeps a track of previous successful resolutions per domain, if current resolution fails it falls back to previous state.

(Not tested)